### PR TITLE
fix: fixes link to marbles syntax docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This library will help you to test your reactive code in easy and clear way.
 # Prerequisites
  - Jest
  - RxJs
- - Familiarity with [marbles syntax](https://github.com/ReactiveX/rxjs/blob/master/docs_app/content/guide/testing/marble-testing.md)
+ - Familiarity with [marbles syntax](https://rxjs.dev/guide/testing/marble-testing#marble-syntax)
 
 # Not supported (but planning to)
  - Time progression syntax

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This library will help you to test your reactive code in easy and clear way.
 # Prerequisites
  - Jest
  - RxJs
- - Familiarity with [marbles syntax](https://github.com/ReactiveX/rxjs/blob/master/doc/writing-marble-tests.md)
+ - Familiarity with [marbles syntax](https://github.com/ReactiveX/rxjs/blob/master/docs_app/content/guide/testing/marble-testing.md)
 
 # Not supported (but planning to)
  - Time progression syntax


### PR DESCRIPTION
I noticed that the link 'marbles syntax' in the `README.md` is pointing to a page which is doesn't exists  anymore. So I changed it.