### PR TITLE
fix: typing for expect if imported from @jest/globals

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -23,6 +23,17 @@ declare global {
   }
 }
 
+// @ts-ignore
+declare module "expect" {
+  interface Matchers<R = void> {
+    toBeObservable(observable: ObservableWithSubscriptions): void;
+    toHaveSubscriptions(marbles: string | string[]): void;
+    toHaveNoSubscriptions(): void;
+    toBeMarble(marble: string): void;
+    toSatisfyOnFlush(func: () => void): void;
+  }
+}
+
 export function hot(marbles: string, values?: any, error?: any): HotObservable {
   return new HotObservable(stripAlignmentChars(marbles), values, error);
 }

--- a/spec/typing-work-for-global-import.spec.ts
+++ b/spec/typing-work-for-global-import.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from '@jest/globals'
+import { cold } from "../index";
+
+describe('', () => {
+  it('Should have typing for expect imported from globals', () => {
+    const a$ = cold("a", { a: 3 })
+
+    expect(a$).toBeObservable(a$);
+  })
+})


### PR DESCRIPTION
This is the PR I promised,

I'm not sure if the @ts-ignore for the module is ok, or if I should type import from @jest/globals