### PR TITLE
fix: fix frame factor

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ import { HotObservable } from './src/rxjs/hot-observable';
 import { Scheduler } from './src/rxjs/scheduler';
 import { stripAlignmentChars } from './src/rxjs/strip-alignment-chars';
 import { Subscription } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
 
 export type ObservableWithSubscriptions = ColdObservable | HotObservable;
 
@@ -95,7 +96,9 @@ beforeEach(() => {
   onFlush = [];
 });
 afterEach(() => {
-  Scheduler.get().run(() => {});
+  Scheduler.get().run(() => {
+    TestScheduler.frameTimeFactor = 10;
+  });
   while (onFlush.length > 0) {
     onFlush.shift()?.();
   }

--- a/spec/to-be-observable.spec.ts
+++ b/spec/to-be-observable.spec.ts
@@ -1,4 +1,4 @@
-import { delay, merge, Subject, timer } from 'rxjs';
+import { delay, merge, Subject, switchMap, timer } from 'rxjs';
 import { concat, mapTo } from 'rxjs/operators';
 import { cold, hot, schedule, Scheduler, time } from '../index';
 
@@ -104,6 +104,13 @@ describe('toBeObservable matcher test', () => {
   it('Should pass if the two objects have the same properties but in different order', () => {
     const e$ = hot('-a', { a: { someprop: 'hey', b: 1 } });
     expect(e$).toBeObservable(cold('-b', { b: { b: 1, someprop: 'hey' } }));
+  });
+
+  it('Should work with cold observables created during assertion execution', () => {
+    const source = cold('a').pipe(switchMap(() => cold('--a')));
+    const expected = cold('--a');
+
+    expect(source).toBeObservable(expected);
   });
 
   // TODO: uncomment once .not.toBeObservable works


### PR DESCRIPTION
Closes: #573

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When `TestScheduler.run` is called, it alters `TestScheduler.frameTimeFactor` from 10 to 1 during its execution. Observables, whether cold or hot, created outside the `run` function, continue to use the original `frameTimeFactor` of 10. However, those created within the `run` function adopt the new `frameTimeFactor` of 1. 

Issue Number: #573

## What is the new behavior?

Within the run function, we set `frameTimeFactor` back to 10.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
